### PR TITLE
Adicionar Dropcota à seção White Labels

### DIFF
--- a/src/app/constants/portfolio.ts
+++ b/src/app/constants/portfolio.ts
@@ -3,7 +3,7 @@ export type PortfolioItem = {
   description: string;
   link: string;
   image: string;
-  category: 'sites' | 'systems' | 'automations';
+  category: 'sites' | 'systems' | 'automations' | 'white-labels';
 };
 
 export const portfolioItems: PortfolioItem[] = [
@@ -70,7 +70,7 @@ export const portfolioItems: PortfolioItem[] = [
       "Sistema inovador de gestão e automação para rifas e sorteios. Plataforma inteligente que revoluciona a organização de rifas, oferecendo ferramentas avançadas para gestão de participantes, sorteios automáticos e controle completo de prêmios. Transforme suas rifas em experiências digitais seguras e emocionantes.",
     link: "https://dropcota.fun",
     image: "/portfolio/dropcota.png",
-    category: "systems",
+    category: "white-labels",
   },
   {
     name: 'Agente de IA para Atendimento ao Cliente',

--- a/src/app/portfolio/components/WhiteLabels.tsx
+++ b/src/app/portfolio/components/WhiteLabels.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import Image from 'next/image';
+import { portfolioItems, PortfolioItem } from '../../constants/portfolio';
+
+export default function WhiteLabels() {
+  const whiteLabels: PortfolioItem[] = portfolioItems.filter(item => item.category === 'white-labels');
+
+  return (
+    <div className="py-16 px-4 sm:px-6 lg:px-8 bg-white dark:bg-gray-900">
+        <div className="max-w-7xl mx-auto">
+            <h2 className="text-4xl font-extrabold tracking-tight text-gray-900 dark:text-white sm:text-5xl lg:text-6xl">
+                White Labels
+            </h2>
+            <p className="mt-4 text-xl text-gray-500 dark:text-gray-400 max-w-3xl">
+                Soluções personalizáveis desenvolvidas para serem reutilizadas e adaptadas para diferentes marcas e necessidades. 
+                Nossos white labels oferecem funcionalidades robustas com a flexibilidade de personalização total, 
+                permitindo que empresas implementem rapidamente soluções profissionais com sua própria identidade visual.
+            </p>
+        </div>
+        <div className="max-w-7xl mx-auto mt-12 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {whiteLabels.map((whiteLabel, index) => (
+                <div
+                    key={index}
+                    className="relative flex flex-col rounded-lg border border-gray-300 bg-white dark:bg-gray-800 dark:border-gray-700 shadow-md overflow-hidden transition-shadow hover:shadow-lg"
+                >
+                    <a href={whiteLabel.link} target="_blank" rel="noopener noreferrer">
+                        <div className="relative w-full aspect-[16/9] bg-gray-50 dark:bg-gray-900">
+                            <Image
+                                src={whiteLabel.image}
+                                alt={whiteLabel.name}
+                                fill
+                                className="object-contain hover:opacity-80 transition-opacity duration-300"
+                            />
+                        </div>
+                    </a>
+                    <div className="flex flex-col justify-between flex-grow p-6">
+                        <div>
+                            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+                                <a href={whiteLabel.link} target="_blank" rel="noopener noreferrer" className="hover:underline">
+                                    {whiteLabel.name}
+                                </a>
+                            </h3>
+                            <p className="text-gray-500 dark:text-gray-400">{whiteLabel.description}</p>
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    </div>
+  );
+}

--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -1,6 +1,7 @@
 import Sites from './components/Sites';
 import Sistemas from './components/Sistemas';
 import Automations from './components/Automations';
+import WhiteLabels from './components/WhiteLabels';
 
 export default function Portfolio() {
   return (
@@ -34,6 +35,11 @@ export default function Portfolio() {
         <section id="automacoes" className="mb-12">
           <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
             <Automations />
+          </div>
+        </section>
+        <section id="white-labels" className="mb-12">
+          <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
+            <WhiteLabels />
           </div>
         </section>
       </div>


### PR DESCRIPTION
Add a 'White Labels' section to the portfolio and reclassify 'Dropcota' under this new category.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8df774d-aae2-45b4-9bef-66200e622708">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8df774d-aae2-45b4-9bef-66200e622708">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

