### PR TITLE
Organize portfolio items for display

### DIFF
--- a/src/app/portfolio/page.tsx
+++ b/src/app/portfolio/page.tsx
@@ -22,6 +22,11 @@ export default function Portfolio() {
       </div>
 
       <div className="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+        <section id="white-labels" className="mb-12">
+          <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
+            <WhiteLabels />
+          </div>
+        </section>
         <section id="sites" className="mb-12">
           <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
             <Sites />
@@ -35,11 +40,6 @@ export default function Portfolio() {
         <section id="automacoes" className="mb-12">
           <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
             <Automations />
-          </div>
-        </section>
-        <section id="white-labels" className="mb-12">
-          <div className="max-w-lg mx-auto md:max-w-none md:grid md:grid-cols-1 md:gap-8">
-            <WhiteLabels />
           </div>
         </section>
       </div>


### PR DESCRIPTION
Reorder portfolio sections to display White Label first, followed by Site, Sistemas, and Automações.

---
<a href="https://cursor.com/background-agent?bcId=bc-c549109e-04d1-4952-a597-552c908fc730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c549109e-04d1-4952-a597-552c908fc730">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

